### PR TITLE
Add loader option to sample Next config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Finally configure your next.config.js to allow loading images from the Sanity.io
 ```javascript
 module.exports = {
 	images: {
-		domains: ['cdn.sanity.io']
+		domains: ['cdn.sanity.io'],
+		loader: 'custom'
 	}
 };
 ```


### PR DESCRIPTION
Static export builds were failing with the following error:

> Error: Image Optimization using Next.js' default loader is not compatible with `next export`.

[Adding the `"loader": "custom"` option to next.config.js](https://github.com/vercel/next.js/issues/21079#issuecomment-899535752) silences this error and the export works as expected.

Related to: https://github.com/vercel/next.js/issues/21079