### PR TITLE
Expand peer dependency range for nextjs 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "peerDependencies": {
         "@sanity/client": "^2.11.0",
-        "next": "^11.0.0",
+        "next": "^11.0.0 || ^12.0.0",
         "react": "^17.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^2.11.0",
-    "next": "^11.0.0",
+    "next": "^11.0.0 ^12.0.0",
     "react": "^17.0.2"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^2.11.0",
-    "next": "^11.0.0 ^12.0.0",
+    "next": "^11.0.0 || ^12.0.0",
     "react": "^17.0.2"
   },
   "repository": {


### PR DESCRIPTION
The package works well with next 12, it's only not listed in the peerDependencies. This PR widens the peerDependencies to support also v12