### PR TITLE
Bump @sanity/client version of devDep and peerDep to ^3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.2.1",
-        "@sanity/client": "^2.1.4",
+        "@sanity/client": "^3.1.0",
         "@testing-library/react-hooks": "^7.0.0",
         "@types/jest": "^26.0.24",
         "@types/next": "^9.0.0",
@@ -37,7 +37,7 @@
         "typescript": "^4.3.2"
       },
       "peerDependencies": {
-        "@sanity/client": "^2.11.0",
+        "@sanity/client": "^3.1.0",
         "next": "^11.0.0 || ^12.0.0",
         "react": "^17.0.2"
       }
@@ -2000,12 +2000,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@rexxars/eventsource-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
-      "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw==",
-      "dev": true
-    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
@@ -2042,34 +2036,36 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.1.4.tgz",
-      "integrity": "sha512-3S5+9Q0StcDUN9M2a+YJqnbTshV0Zx/9f3fig/DC3FJQp8stdplwZ3b5nQ+D9G5fciT0UsaS2DuAK+OXXGfpLw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-3.1.0.tgz",
+      "integrity": "sha512-DtyCtAWNsDgLlEI8y4Zm9L2R1KBe5/BEVQoyD7V2ebScqH9n68nIq4cg//uTjyvvzSwZM2hmV6dd5ZXhvAdk7Q==",
       "dev": true,
       "dependencies": {
-        "@sanity/eventsource": "2.1.4",
-        "@sanity/generate-help-url": "2.1.4",
-        "@sanity/observable": "2.0.9",
-        "deep-assign": "^2.0.0",
-        "get-it": "^5.0.3",
+        "@sanity/eventsource": "^3.0.1",
+        "@sanity/generate-help-url": "^2.18.0",
+        "get-it": "^6.0.0",
         "make-error": "^1.3.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "rxjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sanity/eventsource": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.1.4.tgz",
-      "integrity": "sha512-EGcVBLAFpUX2l9PeH/9Xhj0P7y9BBkvR3JoxNBkQL3lavYZOOoJ77bewaajY5DbMpRPNFjyUTLLOwpElRV4o1A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-3.0.1.tgz",
+      "integrity": "sha512-xeMzr0wK/1+lawSicDg8yA7mdoNY3SKtr70CCsb1ltWbtYtsgZWjKeqNivNAWofxSU2GN7yU23HPzyk6Tx9fkA==",
       "dev": true,
       "dependencies": {
-        "@rexxars/eventsource-polyfill": "^1.0.0",
+        "event-source-polyfill": "^1.0.25",
         "eventsource": "^1.0.6"
       }
     },
     "node_modules/@sanity/generate-help-url": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.1.4.tgz",
-      "integrity": "sha512-zMpTeTnd9615/s5DeH54PKU/KShPIkulIeNHRVLeL4EYNGlf2qcfUfbg4LddBEHlvg4ZPMb2MoBFjU8jSqWqQw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.18.0.tgz",
+      "integrity": "sha512-If8Qkw32LWPes16UzqwUsTLgfxF5d4ACdUvCLMl6grJc/5G8LKPAGCQUuA/d1F4W16yCJVV7Zv31HDRDXJSJkg==",
       "dev": true
     },
     "node_modules/@sanity/image-url": {
@@ -2078,16 +2074,6 @@
       "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@sanity/observable": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-2.0.9.tgz",
-      "integrity": "sha512-IUpzsEbhOhofTBUu2tiQ4Ymbkmhr6oe4UC4Ds1khZ9Td4t4mzzPGmGQIr5SBEDawz0UD7ZgZAb4LeEzV3hUrtA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "rxjs": "^6.5.3"
       }
     },
     "node_modules/@sanity/timed-out": {
@@ -3721,15 +3707,18 @@
       "dev": true
     },
     "node_modules/decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "dependencies": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^3.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -3737,18 +3726,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "node_modules/deep-assign": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
-      "integrity": "sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=",
-      "dev": true,
-      "dependencies": {
-        "is-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
@@ -4512,6 +4489,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==",
+      "dev": true
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4521,9 +4504,9 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "dev": true,
       "dependencies": {
         "original": "^1.0.0"
@@ -4824,9 +4807,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true,
       "funding": [
         {
@@ -4940,33 +4923,32 @@
       }
     },
     "node_modules/get-it": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.3.tgz",
-      "integrity": "sha512-S/QxA9/P4e0tHPILIdf92FVYrE0vre7ChXXMZoILuU4/keatMqnW1KAzCEOH8toJVbj+hgrOnZdUxd9ruG7lsQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-6.0.1.tgz",
+      "integrity": "sha512-tZMsIu4VatXy2RT3M1sStmqn5U0JI6JratUi5kNV/SKpF14+2hssT9J+C51HVO8BPc34fuYVO9W9OzqhbZyQ4A==",
       "dev": true,
       "dependencies": {
         "@sanity/timed-out": "^4.0.2",
         "create-error-class": "^3.0.2",
         "debug": "^2.6.8",
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^6.0.0",
         "follow-redirects": "^1.2.4",
         "form-urlencoded": "^2.0.7",
-        "in-publish": "^2.0.0",
         "into-stream": "^3.1.0",
         "is-plain-object": "^2.0.4",
         "is-retry-allowed": "^1.1.0",
         "is-stream": "^1.1.0",
         "nano-pubsub": "^1.0.2",
         "object-assign": "^4.1.1",
-        "parse-headers": "^2.0.1",
+        "parse-headers": "^2.0.4",
         "progress-stream": "^2.0.0",
         "same-origin": "^0.1.1",
-        "simple-concat": "^1.0.0",
+        "simple-concat": "^1.0.1",
         "tunnel-agent": "^0.6.0",
         "url-parse": "^1.1.9"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/get-orientation": {
@@ -5407,18 +5389,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/in-publish": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
-      "dev": true,
-      "bin": {
-        "in-install": "in-install.js",
-        "in-publish": "in-publish.js",
-        "not-in-install": "not-in-install.js",
-        "not-in-publish": "not-in-publish.js"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5645,15 +5615,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -8856,12 +8817,15 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -9515,9 +9479,9 @@
       }
     },
     "node_modules/parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
       "dev": true
     },
     "node_modules/parse5": {
@@ -10220,9 +10184,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
@@ -11214,9 +11178,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -13144,12 +13108,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@rexxars/eventsource-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
-      "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw==",
-      "dev": true
-    },
     "@rollup/plugin-typescript": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
@@ -13172,50 +13130,39 @@
       }
     },
     "@sanity/client": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.1.4.tgz",
-      "integrity": "sha512-3S5+9Q0StcDUN9M2a+YJqnbTshV0Zx/9f3fig/DC3FJQp8stdplwZ3b5nQ+D9G5fciT0UsaS2DuAK+OXXGfpLw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-3.1.0.tgz",
+      "integrity": "sha512-DtyCtAWNsDgLlEI8y4Zm9L2R1KBe5/BEVQoyD7V2ebScqH9n68nIq4cg//uTjyvvzSwZM2hmV6dd5ZXhvAdk7Q==",
       "dev": true,
       "requires": {
-        "@sanity/eventsource": "2.1.4",
-        "@sanity/generate-help-url": "2.1.4",
-        "@sanity/observable": "2.0.9",
-        "deep-assign": "^2.0.0",
-        "get-it": "^5.0.3",
+        "@sanity/eventsource": "^3.0.1",
+        "@sanity/generate-help-url": "^2.18.0",
+        "get-it": "^6.0.0",
         "make-error": "^1.3.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "rxjs": "^6.0.0"
       }
     },
     "@sanity/eventsource": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.1.4.tgz",
-      "integrity": "sha512-EGcVBLAFpUX2l9PeH/9Xhj0P7y9BBkvR3JoxNBkQL3lavYZOOoJ77bewaajY5DbMpRPNFjyUTLLOwpElRV4o1A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-3.0.1.tgz",
+      "integrity": "sha512-xeMzr0wK/1+lawSicDg8yA7mdoNY3SKtr70CCsb1ltWbtYtsgZWjKeqNivNAWofxSU2GN7yU23HPzyk6Tx9fkA==",
       "dev": true,
       "requires": {
-        "@rexxars/eventsource-polyfill": "^1.0.0",
+        "event-source-polyfill": "^1.0.25",
         "eventsource": "^1.0.6"
       }
     },
     "@sanity/generate-help-url": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.1.4.tgz",
-      "integrity": "sha512-zMpTeTnd9615/s5DeH54PKU/KShPIkulIeNHRVLeL4EYNGlf2qcfUfbg4LddBEHlvg4ZPMb2MoBFjU8jSqWqQw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.18.0.tgz",
+      "integrity": "sha512-If8Qkw32LWPes16UzqwUsTLgfxF5d4ACdUvCLMl6grJc/5G8LKPAGCQUuA/d1F4W16yCJVV7Zv31HDRDXJSJkg==",
       "dev": true
     },
     "@sanity/image-url": {
       "version": "0.140.22",
       "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
       "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA=="
-    },
-    "@sanity/observable": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-2.0.9.tgz",
-      "integrity": "sha512-IUpzsEbhOhofTBUu2tiQ4Ymbkmhr6oe4UC4Ds1khZ9Td4t4mzzPGmGQIr5SBEDawz0UD7ZgZAb4LeEzV3hUrtA==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "rxjs": "^6.5.3"
-      }
     },
     "@sanity/timed-out": {
       "version": "4.0.2",
@@ -14509,12 +14456,12 @@
       "dev": true
     },
     "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^3.1.0"
       }
     },
     "dedent": {
@@ -14522,15 +14469,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-assign": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
-      "integrity": "sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=",
-      "dev": true,
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -15102,15 +15040,21 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==",
+      "dev": true
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "dev": true,
       "requires": {
         "original": "^1.0.0"
@@ -15351,9 +15295,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "foreach": {
@@ -15434,28 +15378,27 @@
       }
     },
     "get-it": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.3.tgz",
-      "integrity": "sha512-S/QxA9/P4e0tHPILIdf92FVYrE0vre7ChXXMZoILuU4/keatMqnW1KAzCEOH8toJVbj+hgrOnZdUxd9ruG7lsQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-6.0.1.tgz",
+      "integrity": "sha512-tZMsIu4VatXy2RT3M1sStmqn5U0JI6JratUi5kNV/SKpF14+2hssT9J+C51HVO8BPc34fuYVO9W9OzqhbZyQ4A==",
       "dev": true,
       "requires": {
         "@sanity/timed-out": "^4.0.2",
         "create-error-class": "^3.0.2",
         "debug": "^2.6.8",
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^6.0.0",
         "follow-redirects": "^1.2.4",
         "form-urlencoded": "^2.0.7",
-        "in-publish": "^2.0.0",
         "into-stream": "^3.1.0",
         "is-plain-object": "^2.0.4",
         "is-retry-allowed": "^1.1.0",
         "is-stream": "^1.1.0",
         "nano-pubsub": "^1.0.2",
         "object-assign": "^4.1.1",
-        "parse-headers": "^2.0.1",
+        "parse-headers": "^2.0.4",
         "progress-stream": "^2.0.0",
         "same-origin": "^0.1.1",
-        "simple-concat": "^1.0.0",
+        "simple-concat": "^1.0.1",
         "tunnel-agent": "^0.6.0",
         "url-parse": "^1.1.9"
       }
@@ -15763,12 +15706,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "in-publish": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -15915,12 +15852,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -18406,9 +18337,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -18920,9 +18851,9 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
       "dev": true
     },
     "parse5": {
@@ -19447,9 +19378,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -20210,9 +20141,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.1",
-    "@sanity/client": "^2.1.4",
+    "@sanity/client": "^3.1.0",
     "@testing-library/react-hooks": "^7.0.0",
     "@types/jest": "^26.0.24",
     "@types/next": "^9.0.0",
@@ -42,7 +42,7 @@
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
-    "@sanity/client": "^2.11.0",
+    "@sanity/client": "^3.1.0",
     "next": "^11.0.0 || ^12.0.0",
     "react": "^17.0.2"
   },


### PR DESCRIPTION
### Issues/PRs
Respond to issue #35 

### Description
Bump up the npm devDependencies and peerDependencies of @sanity/client to ^3.1.0.
This is inline with any developers starting their new project with the new sanity client which making it failed to run `npm install`

### SemVer
This is a breaking changes of peerDeps, which means if we're strictly following SemVer, it should only be release on the next major version.