### PR TITLE
Fix: Mismatch Placeholder Type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -50,5 +50,5 @@ export type UseNextSanityImageProps = {
 	width: number;
 	height: number;
 	blurDataURL?: string;
-	placeholder: string;
+	placeholder: 'blur' | 'empty';
 };


### PR DESCRIPTION
# Fix: Mismatch Placeholder Type
After running into the same issue as #33, I decided to submit this PR to rectify the typing.
The current typing error exists due to the mismatch in typing between nextjs' `PlaceholderValue` type and the `string` type.

`Type 'string' is not assignable to type 'PlaceholderValue'.ts(2322)`.

As Next.js currently doesn't export the `PlaceholderValue` type, the type is manually set. The type is `'blur' | 'empty'` with no `undefined` included due to the value always defaulting to `'empty'`. If the type is somehow exported in the future for us to use, it should be updated to point to that type.

Currently passing all tests!