### PR TITLE
docs: add note on how to use without Sanity Client instance and how to use with RSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,35 @@ const Page = ({ mySanityData }) => {
 // ... see "Responsive layout"
 ```
 
+## App Router / Server Components
+
+In order to use the custom image loader with the Next.js image component, you must use client component since the loader function cannot be passed from a server component into the Image component (which is a client component). For example:
+
+```
+'use client'
+
+const MySanityImage = ({ mySanityData }) => {
+	const imageProps = useNextSanityImage(configuredSanityClient, mySanityData.image);
+
+	return (
+		<Img {...imageProps} />
+	);
+};
+```
+
+Note that this will cause the entire @sanity/client package to be included in your client side bundle. You can avoid this by opting to pass your project ID and dataset as a config object rather than passing in an entire Sanity Client instance:
+
+```
+const imageProps = useNextSanityImage({
+	config: () => ({
+		projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+		dataset: process.env.NEXT_PUBLIC_SANITY_DATASET
+	})
+}, mySanityData.image);
+```
+
+As long as the Sanity Client isn't being included somewhere else in your project, this will significantly reduce the size of your client bundle compared to when providing the entire Sanity Client instance.
+
 ## API
 
 ### useNextSanityImage

--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ Utility for using images hosted on the [Sanity.io CDN](https://sanity.io) with t
 npm install --save next-sanity-image
 ```
 
-This library also expects you to pass in a [SanityClient instance](https://www.npmjs.com/package/@sanity/client), if you haven't installed this already:
-
-```
-npm install --save @sanity/client
-```
-
-Finally configure your next.config.js to allow loading images from the Sanity.io CDN
+Configure your next.config.js to allow loading images from the Sanity.io CDN
 
 ```javascript
 // next.config.js
@@ -171,9 +165,20 @@ const Page = ({ mySanityData }) => {
 
 React hook which handles generating a URL for each of the defined sizes in the [image sizes](https://nextjs.org/docs/basic-features/image-optimization#image-sizes) and [device sizes](https://nextjs.org/docs/basic-features/image-optimization#device-sizes) Next.js options.
 
-#### sanityClient: [`SanityClient`](https://www.npmjs.com/package/@sanity/client)
+#### sanityClient: [`SanityClient | SanityModernClientLike`](https://www.npmjs.com/package/@sanity/client)
 
 Pass in a configured instance of the SanityClient, used for building the URL using the [@sanity/image-url builder](https://www.npmjs.com/package/@sanity/image-url).
+
+Alternatively, you can skip passing an instance of the Sanity client and instead pass a SanityModernClientLike object containing your dataset and project ID:
+
+```
+{
+	config: () => ({
+		projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+		dataset: process.env.NEXT_PUBLIC_SANITY_DATASET
+	})
+}
+```
 
 #### image: [`SanityImageSource` | `null`](https://www.npmjs.com/package/@sanity/image-url#imagesource)
 


### PR DESCRIPTION
See #42.

Not passing in the entire Sanity Client actually significantly reduced the bundle size, in my case from 131kB to 102kB for First Load JS. IMO this should probably be the default recommendation.

I went ahead and removed the `npm install --save @sanity/client` part from the readme since it actually isn't strictly needed and many projects will probably already have it.

This PR also adds a note on how to use with Server Components in the App Router. The default example in the readme won't work in a Server Component since the `loader` cannot be set in a Server Component:

> Unhandled Runtime Error Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server"

The Image component, being a Client Component, needs to be wrapped in another Client component in order to pass a custom loader to it.

Thanks for your work on this package!